### PR TITLE
Fix test issue

### DIFF
--- a/examples/wdio-cjs/wdio.conf.js
+++ b/examples/wdio-cjs/wdio.conf.js
@@ -14,7 +14,7 @@ exports.config = {
   framework: 'mocha',
   reporters: ['spec'],
 
-  services: [['qunit', { autostartDelay: 1000 }]],
+  services: [['qunit', { autostartDelay: 5000 }]],
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,8 @@ async function QunitFinishedEventInBrowserContext(
     });
     const automaticRunStartPromise = new Promise<void>((resolve) => {
       window.setTimeout(() => {
-        if (!started) {
+        if (!started && !window.QUnit.config.started) {
+          started = true;
           console.debug('QUnit started automatically by service'); // eslint-disable-line no-console
           window.QUnit.start();
           resolve();


### PR DESCRIPTION
# Summary

Some integration tests would occasionally double start, this was likely caused by a race condition or simply not waiting long enough prior to starting the tests. Added an additional delay and fixed potential race condition.